### PR TITLE
Implemented Prism.js

### DIFF
--- a/js/gimmicks/highlight.js
+++ b/js/gimmicks/highlight.js
@@ -15,14 +15,21 @@
         // marked adds lang-ruby, lang-csharp etc to the <code> block like in GFM
         var $codeblocks = $('pre code[class^=lang-]');
         return $codeblocks.each(function() {
-            var $this = $(this);
-            var classes = $this.attr('class');
+
+            var $this, classes, lang, parent, $parent;
+            $this = $(this);
+            classes = $this.attr('class');
+
             // TODO check for other classes and only find the lang- one
             // highlight doesnt want a lang- prefix
-            var lang = classes.substring(5);
+            lang = classes.substring(5);
             $this.removeClass(classes);
-            $this.addClass(lang);
-            var x = hljs.highlightBlock($this[0]);
+
+            parent = $this[0].parentElement;
+            $parent = $(parent);
+            $parent.addClass("language-" + lang);
+            Prism.highlightElement(parent, true, function() {});
+
         });
     }
 


### PR DESCRIPTION
Although prism was being loaded in index.html, it appeared that Highlight.js was being referenced in the `highlight()` method.  So, I updated the code to use Prism.js instead.